### PR TITLE
Develop Runtime

### DIFF
--- a/.build/Sucrose.ps1
+++ b/.build/Sucrose.ps1
@@ -37,7 +37,7 @@
     Number of retry attempts per project. Default: 3
 
 .PARAMETER RetryDelay
-    Delay between retries in seconds. Default: 2
+    Delay between retries in seconds. Default: 3
 
 .PARAMETER InstallRuntime
     If true, installs .NET runtimes. Default: true
@@ -46,7 +46,7 @@
     If true, compresses the published package using 7zip. Default: true
 
 .PARAMETER DotNetVersion
-    Version of .NET to install. Default: 9.0.305
+    Version of .NET to install. Default: 9.0.306
 
 .EXAMPLE
     .\Sucrose.ps1
@@ -108,7 +108,7 @@ param (
     [string]$CompressPackage = "true",
 
     [Parameter(HelpMessage = ".NET version to install")]
-    [string]$DotNetVersion = "9.0.305"
+    [string]$DotNetVersion = "9.0.306"
 )
 
 #region Initialization

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="WindowsAPICodePackShell" Version="8.0.8" />
     <PackageVersion Include="CefSharp.Wpf.HwndHost" Version="140.1.140" />
     <PackageVersion Include="WPF-UI.DependencyInjection" Version="4.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.10" />
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3590-prerelease" />
   </ItemGroup>
 </Project>

--- a/src/Library/Sucrose.Transmission/Helper/TransmissionClient.cs
+++ b/src/Library/Sucrose.Transmission/Helper/TransmissionClient.cs
@@ -6,49 +6,105 @@ namespace Sucrose.Transmission.Helper
     internal class TransmissionClient : IDisposable
     {
         private bool _isConnected;
-        private StreamWriter _writer;
         private TcpClient _tcpClient;
+        private StreamWriter _writer;
+        private readonly SemaphoreSlim _sendSemaphore = new(1, 1);
 
         public bool IsConnected => _tcpClient?.Connected ?? false;
 
         public async Task Start(IPAddress host, int port)
         {
-            _tcpClient = new();
-
-            await _tcpClient.ConnectAsync(host, port);
-
-            _isConnected = true;
-
-            NetworkStream stream = _tcpClient.GetStream();
-
-            _writer = new StreamWriter(stream)
+            try
             {
-                AutoFlush = true
-            };
+                // Ensure clean state
+                if (_tcpClient != null)
+                {
+                    await Stop();
+                }
+
+                _tcpClient = new TcpClient();
+
+                // Set timeout for connection (5 seconds)
+                using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
+
+                await _tcpClient.ConnectAsync(host, port, cts.Token);
+
+                if (_tcpClient.Connected)
+                {
+                    _isConnected = true;
+
+                    // Configure keep-alive
+                    _tcpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+                    _tcpClient.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, 10);
+                    _tcpClient.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, 2);
+
+                    // Set receive and send timeouts
+                    _tcpClient.ReceiveTimeout = 5000; // 5 seconds
+                    _tcpClient.SendTimeout = 2500; // 2.5 seconds
+
+                    NetworkStream stream = _tcpClient.GetStream();
+
+                    _writer = new StreamWriter(stream)
+                    {
+                        AutoFlush = true
+                    };
+                }
+                else
+                {
+                    throw new InvalidOperationException("Failed to establish connection");
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                _isConnected = false;
+
+                throw new TimeoutException($"Connection to {host}:{port} timed out");
+            }
+            catch (SocketException Exception)
+            {
+                _isConnected = false;
+
+                await Stop();
+                throw new InvalidOperationException($"Failed to connect to {host}:{port}: {Exception.Message}", Exception);
+            }
+            catch (Exception)
+            {
+                _isConnected = false;
+
+                await Stop();
+                throw;
+            }
         }
 
         public async Task Stop()
         {
             _isConnected = false;
 
-            if (_writer != null)
+            try
             {
-                await _writer.DisposeAsync();
-
-                _writer = null;
-            }
-
-            if (_tcpClient != null)
-            {
-                if (_tcpClient.Connected)
+                if (_writer != null)
                 {
-                    _tcpClient.Close();
+                    await _writer.DisposeAsync();
+
+                    _writer = null;
                 }
-
-                await Task.Run(() => _tcpClient.Dispose());
-
-                _tcpClient = null;
             }
+            catch { }
+
+            try
+            {
+                if (_tcpClient != null)
+                {
+                    if (_tcpClient.Connected)
+                    {
+                        _tcpClient.Close();
+                    }
+
+                    _tcpClient.Dispose();
+                    _tcpClient = null;
+                }
+            }
+            catch { }
         }
 
         public async Task SendMessage(string Message)
@@ -60,13 +116,36 @@ namespace Sucrose.Transmission.Helper
 
             if (!string.IsNullOrWhiteSpace(Message))
             {
-                await _writer.WriteLineAsync(Message);
+                await _sendSemaphore.WaitAsync();
+
+                try
+                {
+                    await _writer.WriteLineAsync(Message);
+                }
+                catch (IOException Exception)
+                {
+                    _isConnected = false;
+
+                    throw new InvalidOperationException("Failed to send message. Connection may be lost.", Exception);
+                }
+                catch (ObjectDisposedException)
+                {
+                    _isConnected = false;
+
+                    throw new InvalidOperationException("Connection is closed.");
+                }
+                finally
+                {
+                    _sendSemaphore.Release();
+                }
             }
         }
 
         public void Dispose()
         {
             _ = Stop();
+
+            _sendSemaphore?.Dispose();
         }
     }
 }

--- a/src/Library/Sucrose.Transmission/Helper/TransmissionServer.cs
+++ b/src/Library/Sucrose.Transmission/Helper/TransmissionServer.cs
@@ -10,63 +10,126 @@ namespace Sucrose.Transmission.Helper
         private TcpClient _client;
         private StreamReader _reader;
         private TcpListener _tcpListener;
+        private readonly SemaphoreSlim _clientLock = new(1, 1);
         private CancellationTokenSource _cancellationTokenSource;
 
         public bool IsConnected => _client?.Connected ?? false;
 
         public async Task Start(IPAddress host, int port, EventHandler<STEMREA> eventHandler)
         {
+            // Ensure clean state
+            if (_tcpListener != null)
+            {
+                await Stop();
+            }
+
             _isRunning = true;
             _cancellationTokenSource = new CancellationTokenSource();
 
             _tcpListener = new TcpListener(host, port);
             _tcpListener.Start();
 
-            while (_isRunning)
+            while (_isRunning && !_cancellationTokenSource.Token.IsCancellationRequested)
             {
                 try
                 {
-                    _client = await _tcpListener.AcceptTcpClientAsync();
+                    // Accept client with cancellation support
+                    using CancellationTokenSource acceptCts = CancellationTokenSource.CreateLinkedTokenSource(_cancellationTokenSource.Token);
+                    acceptCts.CancelAfter(TimeSpan.FromSeconds(5)); // 5 second timeout for accepting connections
+
+                    Task<TcpClient> tcpClientTask = _tcpListener.AcceptTcpClientAsync();
+                    TaskCompletionSource<bool> acceptTcs = new();
+
+                    using (acceptCts.Token.Register(() => acceptTcs.TrySetCanceled()))
+                    {
+                        Task completedTask = await Task.WhenAny(tcpClientTask, acceptTcs.Task);
+
+                        if (completedTask == acceptTcs.Task)
+                        {
+                            continue; // Timeout or cancellation
+                        }
+
+                        _client = await tcpClientTask;
+                    }
+
+                    // Configure the accepted client
+                    ConfigureClient(_client);
+
                     NetworkStream stream = _client.GetStream();
                     _reader = new StreamReader(stream);
 
-                    while (_isRunning && _client.Connected)
+                    while (_isRunning && _client.Connected && !_cancellationTokenSource.Token.IsCancellationRequested)
                     {
                         try
                         {
-                            string message = await _reader.ReadLineAsync();
+                            // Read with timeout
+                            using CancellationTokenSource readCts = CancellationTokenSource.CreateLinkedTokenSource(_cancellationTokenSource.Token);
+                            readCts.CancelAfter(TimeSpan.FromSeconds(15)); // 15 second read timeout
 
-                            if (!string.IsNullOrWhiteSpace(message))
+                            Task<string> readTask = _reader.ReadLineAsync();
+                            TaskCompletionSource<string> readTcs = new();
+
+                            using (readCts.Token.Register(() => readTcs.TrySetCanceled()))
                             {
-                                eventHandler?.Invoke(this, new STEMREA { Message = message });
+                                Task<string> completedTask = await Task.WhenAny(readTask, readTcs.Task);
+
+                                if (completedTask == readTcs.Task)
+                                {
+                                    break; // Timeout or cancellation
+                                }
+
+                                string message = await readTask;
+                                if (message == null) // End of stream
+                                {
+                                    break;
+                                }
+
+                                if (!string.IsNullOrWhiteSpace(message))
+                                {
+                                    eventHandler?.Invoke(this, new STEMREA { Message = message });
+                                }
                             }
                         }
-                        catch
+                        catch (IOException)
                         {
+                            // Connection lost
+                            break;
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            // Reader disposed
+                            break;
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            // Cancellation requested
                             break;
                         }
                     }
 
-                    if (_reader != null)
-                    {
-                        _reader.Dispose();
-                        _reader = null;
-                    }
-
-                    if (_client != null)
-                    {
-                        _client.Close();
-                        _client.Dispose();
-                        _client = null;
-                    }
+                    // Clean up client connection
+                    await CleanupClient();
                 }
                 catch (OperationCanceledException)
                 {
+                    // Server shutdown requested
                     break;
                 }
-                catch
+                catch (SocketException)
                 {
-                    await Task.Delay(1000);
+                    // Socket error, wait before retry
+                    if (_isRunning)
+                    {
+                        await Task.Delay(1000, _cancellationTokenSource.Token).ConfigureAwait(false);
+                    }
+                }
+                catch (Exception)
+                {
+                    // Unexpected error, wait before retry
+                    if (_isRunning)
+                    {
+                        await Task.Delay(1000, _cancellationTokenSource.Token).ConfigureAwait(false);
+                    }
                 }
             }
         }
@@ -75,37 +138,94 @@ namespace Sucrose.Transmission.Helper
         {
             _isRunning = false;
 
-            if (_cancellationTokenSource != null && !_cancellationTokenSource.IsCancellationRequested)
+            try
             {
-                await _cancellationTokenSource.CancelAsync();
-                _cancellationTokenSource.Dispose();
+                if (_cancellationTokenSource != null && !_cancellationTokenSource.IsCancellationRequested)
+                {
+                    await _cancellationTokenSource.CancelAsync();
+                }
+            }
+            catch { }
+
+            await CleanupClient();
+
+            try
+            {
+                if (_tcpListener != null)
+                {
+                    _tcpListener.Stop();
+                    _tcpListener = null;
+                }
+            }
+            catch { }
+
+            try
+            {
+                _cancellationTokenSource?.Dispose();
                 _cancellationTokenSource = null;
             }
+            catch { }
+        }
 
-            if (_reader != null)
+        private void ConfigureClient(TcpClient client)
+        {
+            if (client != null && client.Connected)
             {
-                _reader.Dispose();
-                _reader = null;
+                // Configure keep-alive
+                client.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+                client.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, 10);
+                client.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, 2);
+
+                // Set timeouts
+                client.ReceiveTimeout = 15000; // 15 seconds
+                client.SendTimeout = 5000; // 5 seconds
             }
+        }
 
-            if (_client != null)
+        private async Task CleanupClient()
+        {
+            await _clientLock.WaitAsync();
+
+            try
             {
-                _client.Close();
-                _client.Dispose();
-                _client = null;
+                if (_reader != null)
+                {
+                    try
+                    {
+                        _reader.Dispose();
+                    }
+                    catch { }
+
+                    _reader = null;
+                }
+
+                if (_client != null)
+                {
+                    try
+                    {
+                        if (_client.Connected)
+                        {
+                            _client.Close();
+                        }
+
+                        _client.Dispose();
+                    }
+                    catch { }
+
+                    _client = null;
+                }
             }
-
-            if (_tcpListener != null)
+            finally
             {
-                _tcpListener.Stop();
-
-                await Task.CompletedTask;
+                _clientLock.Release();
             }
         }
 
         public void Dispose()
         {
             _ = Stop();
+
+            _clientLock?.Dispose();
         }
     }
 }

--- a/src/Library/Sucrose.Transmission/TransmissionT.cs
+++ b/src/Library/Sucrose.Transmission/TransmissionT.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Sockets;
 using STEMREA = Sucrose.Transmission.Event.MessageReceivedEventArgs;
 using STHTC = Sucrose.Transmission.Helper.TransmissionClient;
 using STHTS = Sucrose.Transmission.Helper.TransmissionServer;
@@ -18,13 +19,7 @@ namespace Sucrose.Transmission
         {
             if (!TC.IsConnected)
             {
-                try
-                {
-                    await TC.Stop();
-                }
-                catch { }
-
-                await TC.Start(Host, Port);
+                await StartClientWithRetry();
             }
         }
 
@@ -32,16 +27,30 @@ namespace Sucrose.Transmission
         {
             if (!TC.IsConnected)
             {
-                try
-                {
-                    await TC.Stop();
-                }
-                catch { }
-
-                await TC.Start(Host, Port);
+                await StartClientWithRetry();
             }
 
-            await TC.SendMessage(Message);
+            if (TC.IsConnected)
+            {
+                try
+                {
+                    await TC.SendMessage(Message);
+                }
+                catch (InvalidOperationException Exception)
+                {
+                    // Connection lost, try to reconnect once
+                    await StartClientWithRetry(maxRetries: 1);
+
+                    if (TC.IsConnected)
+                    {
+                        await TC.SendMessage(Message);
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException("Failed to send message after reconnection attempt", Exception);
+                    }
+                }
+            }
         }
 
         public async Task StartServer()
@@ -85,6 +94,65 @@ namespace Sucrose.Transmission
         protected virtual void OnMessageReceived(STEMREA e)
         {
             MessageReceived?.Invoke(this, e);
+        }
+
+        private async Task StartClientWithRetry(int maxRetries = 3)
+        {
+            Exception lastException = null;
+
+            for (int i = 0; i <= maxRetries; i++)
+            {
+                try
+                {
+                    // Clean up previous connection
+                    try
+                    {
+                        await TC.Stop();
+                    }
+                    catch { }
+
+                    // Attempt to connect
+                    await TC.Start(Host, Port);
+
+                    // If successful, return
+                    if (TC.IsConnected)
+                    {
+                        return;
+                    }
+                }
+                catch (TimeoutException Exception)
+                {
+                    lastException = Exception;
+
+                    if (i < maxRetries)
+                    {
+                        // Wait before retry with exponential backoff
+                        await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, i)));
+                    }
+                }
+                catch (InvalidOperationException Exception) when (Exception.InnerException is SocketException)
+                {
+                    lastException = Exception;
+
+                    if (i < maxRetries)
+                    {
+                        // Wait before retry with exponential backoff
+                        await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, i)));
+                    }
+                }
+                catch (Exception Exception)
+                {
+                    lastException = Exception;
+
+                    break; // Don't retry on unexpected exceptions
+                }
+            }
+
+            // If we get here, all retries failed
+            if (lastException != null)
+            {
+                throw new InvalidOperationException($"Failed to connect after {maxRetries} retries", lastException);
+            }
         }
     }
 }

--- a/src/Project/Sucrose.Backgroundog/Helper/Initialize.cs
+++ b/src/Project/Sucrose.Backgroundog/Helper/Initialize.cs
@@ -19,7 +19,7 @@ namespace Sucrose.Backgroundog.Helper
             SBEW.Start();
 
             TimerCallback Callback = InitializeTimer_Callback;
-            SBMI.InitializeTimer = new(Callback, null, 0, SBMI.InitializeTime);
+            SBMI.InitializeTimer = new(Callback, null, SBMI.InitializeDueTime, SBMI.InitializeTime);
 
             SMMI.BackgroundogSettingManager.SetSetting(new KeyValuePair<string, bool>[]
             {

--- a/src/Project/Sucrose.Backgroundog/Helper/Specification.cs
+++ b/src/Project/Sucrose.Backgroundog/Helper/Specification.cs
@@ -1023,28 +1023,70 @@ namespace Sucrose.Backgroundog.Helper
                                 TypeNameHandling = TypeNameHandling.None
                             };
 
-                            await STMI.BackgroundogManager.StartClient(JsonConvert.SerializeObject(new SPIB()
+                            try
                             {
-                                Bios = SBED.GetBiosInfo(),
-                                Date = SBED.GetDateInfo(),
-                                Audio = SBED.GetAudioInfo(),
-                                Memory = SBED.GetMemoryInfo(),
-                                Battery = SBED.GetBatteryInfo(),
-                                Graphic = SBED.GetGraphicInfo(),
-                                Network = SBED.GetNetworkInfo(),
-                                Storage = SBED.GetStorageInfo(),
-                                Processor = SBED.GetProcessorInfo(),
-                                Motherboard = SBED.GetMotherboardInfo()
-                            }, SerializerSettings));
+                                await STMI.BackgroundogManager.StartClient(JsonConvert.SerializeObject(new SPIB()
+                                {
+                                    Bios = SBED.GetBiosInfo(),
+                                    Date = SBED.GetDateInfo(),
+                                    Audio = SBED.GetAudioInfo(),
+                                    Memory = SBED.GetMemoryInfo(),
+                                    Battery = SBED.GetBatteryInfo(),
+                                    Graphic = SBED.GetGraphicInfo(),
+                                    Network = SBED.GetNetworkInfo(),
+                                    Storage = SBED.GetStorageInfo(),
+                                    Processor = SBED.GetProcessorInfo(),
+                                    Motherboard = SBED.GetMotherboardInfo()
+                                }, SerializerSettings));
+                            }
+                            catch (InvalidOperationException Exception) when (Exception.Message.Contains("Failed to connect after"))
+                            {
+                                // Clean up the failed manager
+                                try
+                                {
+                                    await STMI.BackgroundogManager.DisposeClient();
+                                }
+                                catch { }
+
+                                STMI.BackgroundogManager = null;
+
+                                // Connection retries failed, log and skip this cycle
+                                await SSWEW.Watch_CatchException(Exception);
+                            }
+                            catch (TimeoutException Exception)
+                            {
+                                // Clean up the failed manager
+                                try
+                                {
+                                    await STMI.BackgroundogManager.DisposeClient();
+                                }
+                                catch { }
+
+                                STMI.BackgroundogManager = null;
+
+                                // Connection timeout, log and skip this cycle
+                                await SSWEW.Watch_CatchException(Exception);
+                            }
 
                             SBMI.TransmissionManagement = true;
                         }
                     }
                     catch (SocketException Exception)
                     {
+                        // Clean up the existing manager before creating a new one
+                        if (STMI.BackgroundogManager != null)
+                        {
+                            try
+                            {
+                                await STMI.BackgroundogManager.DisposeClient();
+                            }
+                            catch { }
+                        }
+
+                        STMI.BackgroundogManager = null;
                         SBMI.TransmissionManagement = true;
+
                         await SSWEW.Watch_CatchException(Exception);
-                        STMI.BackgroundogManager = new(SMMRG.Loopback, SMMB.TransmissionPort);
                     }
                     catch (Exception Exception)
                     {

--- a/src/Project/Sucrose.Backgroundog/Manage/Internal.cs
+++ b/src/Project/Sucrose.Backgroundog/Manage/Internal.cs
@@ -142,6 +142,8 @@ namespace Sucrose.Backgroundog.Manage
 
         public static PerformanceCounter ProcessorCounter = null;
 
+        public static int InitializeDueTime = InitializeTime * 30;
+
         public static int SpecificationTime = InitializeTime * 20;
 
         public static PerformanceCounter[] ProcessorsCounter = null;

--- a/src/Shared/Sucrose.Shared.Dependency/Helper/Runtime.cs
+++ b/src/Shared/Sucrose.Shared.Dependency/Helper/Runtime.cs
@@ -1,4 +1,5 @@
 ﻿#if RELEASE
+using System.Runtime.InteropServices;
 using SSSMI = Sucrose.Shared.Space.Manage.Internal;
 #endif
 
@@ -13,7 +14,19 @@ namespace Sucrose.Shared.Dependency.Helper
             Environment.SetEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0", EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("DOTNET_ROLL_FORWARD", "LatestMajor", EnvironmentVariableTarget.Process);
 
-            Environment.SetEnvironmentVariable("PATH", $"{SSSMI.Runtime};{SSSMI.This}", EnvironmentVariableTarget.Process);
+            switch (RuntimeInformation.OSArchitecture)
+            {
+                case Architecture.X86:
+                    Environment.SetEnvironmentVariable("DOTNET_ROOT(x86)", SSSMI.Runtime, EnvironmentVariableTarget.Process);
+                    break;
+                case Architecture.Arm64:
+                    Environment.SetEnvironmentVariable("DOTNET_ROOT(arm64)", SSSMI.Runtime, EnvironmentVariableTarget.Process);
+                    break;
+                default:
+                    break;
+            }
+
+            Environment.SetEnvironmentVariable("PATH", $"{SSSMI.Runtime};{SSSMI.This};{Environment.GetEnvironmentVariable("PATH") ?? string.Empty}", EnvironmentVariableTarget.Process);
 #endif
         }
     }


### PR DESCRIPTION
This pull request introduces significant improvements to the reliability, robustness, and error handling of the TCP client-server communication layer in the Sucrose project. The changes focus on making network operations more resilient to failures, adding connection and read timeouts, improving resource cleanup, and enhancing retry logic for client connections. There are also minor updates to dependency versions and configuration defaults.

**Networking robustness and reliability improvements:**

* Refactored `TransmissionClient` and `TransmissionServer` to add connection, send, and receive timeouts, socket keep-alive options, and improved exception handling for all network operations. This includes using `SemaphoreSlim` for thread safety, ensuring proper disposal of resources, and setting socket options for better connection reliability. (`src/Library/Sucrose.Transmission/Helper/TransmissionClient.cs` [[1]](diffhunk://#diff-696e88e4dea9607264990adc1c8b25bc9fc7d35bde35f0df906c7d8b88e58616L9-R108) [[2]](diffhunk://#diff-696e88e4dea9607264990adc1c8b25bc9fc7d35bde35f0df906c7d8b88e58616R118-R148); `src/Library/Sucrose.Transmission/Helper/TransmissionServer.cs` [[3]](diffhunk://#diff-74b3702239ee20e6c82b10a934fc680d62e3dd65b9b463d3cfc3d82380f4fe41R13-R132) [[4]](diffhunk://#diff-74b3702239ee20e6c82b10a934fc680d62e3dd65b9b463d3cfc3d82380f4fe41R141-R228)

* Implemented robust retry logic for client connections with exponential backoff, ensuring the client attempts to reconnect a configurable number of times before failing. This is encapsulated in the new `StartClientWithRetry` method and used throughout client startup and message sending flows. (`src/Library/Sucrose.Transmission/TransmissionT.cs` [[1]](diffhunk://#diff-740d18391eeccdbbea9f6413221c8deecc6d69c7687ae33daf34d42570148d0cL21-R54) [[2]](diffhunk://#diff-740d18391eeccdbbea9f6413221c8deecc6d69c7687ae33daf34d42570148d0cR98-R156)

**Error handling and resource management:**

* Improved error handling in the client and server to ensure that failed or timed-out connections are cleaned up properly, and that exceptions are logged and handled gracefully. This includes catching specific exceptions (e.g., `TimeoutException`, `SocketException`), disposing of failed managers, and updating state accordingly. (`src/Project/Sucrose.Backgroundog/Helper/Specification.cs` [[1]](diffhunk://#diff-f8c3d3e1d3776984471805d29975612c03791d8ed3efe1bf94799ad95f44640eR1026-R1027) [[2]](diffhunk://#diff-f8c3d3e1d3776984471805d29975612c03791d8ed3efe1bf94799ad95f44640eR1041-L1047)

**Configuration and dependency updates:**

* Updated default .NET version from `9.0.305` to `9.0.306` in both the build script and parameters, and increased the retry delay default in the build script. (`.build/Sucrose.ps1` [[1]](diffhunk://#diff-a532eb863e8acbe64abea5a45a45a771b0d8cf4e2434f856979622672cba4493L40-R40) [[2]](diffhunk://#diff-a532eb863e8acbe64abea5a45a45a771b0d8cf4e2434f856979622672cba4493L49-R49) [[3]](diffhunk://#diff-a532eb863e8acbe64abea5a45a45a771b0d8cf4e2434f856979622672cba4493L111-R111)
* Bumped `Microsoft.Extensions.Hosting` NuGet package version from `9.0.9` to `9.0.10`. (`Directory.Packages.props` [Directory.Packages.propsL26-R26](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L26-R26))

**Miscellaneous improvements:**

* Fixed timer initialization to use the correct due time in the background helper. (`src/Project/Sucrose.Backgroundog/Helper/Initialize.cs` [src/Project/Sucrose.Backgroundog/Helper/Initialize.csL22-R22](diffhunk://#diff-1c0db05b5083e7b0ea5840d4a54cee9189bfc74ee615bf63bcf8483deaff893fL22-R22))
* Added missing `using System.Net.Sockets;` directive for socket-related operations. (`src/Library/Sucrose.Transmission/TransmissionT.cs` [src/Library/Sucrose.Transmission/TransmissionT.csR2](diffhunk://#diff-740d18391eeccdbbea9f6413221c8deecc6d69c7687ae33daf34d42570148d0cR2))

These changes collectively make the TCP communication layer more robust against network failures and improve the maintainability and reliability of the application.